### PR TITLE
Modified callbacks structure

### DIFF
--- a/Examples/1-SimpleInteractiveDashApp/simple_callback.m
+++ b/Examples/1-SimpleInteractiveDashApp/simple_callback.m
@@ -1,0 +1,33 @@
+terminate(pyenv);
+clearvars; % Removes all variables from the currently active workspace.
+
+uifig = uifigure('visible', 'off');
+size = [12, 12];
+uigrid = uigridlayout(uifig, size);
+
+textHeader = uilabel(uigrid,...
+    'Text', 'Change the value in the text box to see callbacks in action!',...
+    'FontSize', 18, 'FontWeight', 'bold');
+
+textInput = uilabel(uigrid, 'Text', 'Input: ');
+textInput.Layout.Row = 2;
+textInput.Layout.Column = 1;
+
+inputEditField = uieditfield(uigrid,...
+    'Value', 'initial value', 'Tag', 'my-input');
+inputEditField.Layout.Row = 2;
+
+textOutput = uilabel(uigrid, 'Tag', 'my-output');
+textOutput.Layout.Row = 3;
+
+% Define the callbacks.
+args = {...
+    argsOut('my-output', 'children'),...
+    argsIn('my-input','value')};
+
+handle = useCallback('update_output_div');
+
+callbackDat = {args, handle};
+
+% Run the app.
+app = startDash(uigrid, 8057, callbackDat);

--- a/Examples/1-SimpleInteractiveDashApp/update_output_div.m
+++ b/Examples/1-SimpleInteractiveDashApp/update_output_div.m
@@ -1,0 +1,3 @@
+function outTxt = update_output_div(input_value)
+    outTxt = {sprintf('Output: %s', input_value)};
+end

--- a/helper_functions/callbackP.py
+++ b/helper_functions/callbackP.py
@@ -1,0 +1,9 @@
+import matlab.engine
+import json
+
+future = matlab.engine.start_matlab(background=True)
+eng = future.result()
+
+def callback(*args):
+    outputs = eval('eng.'+callbackMatlabFunction+'(*args)')
+    return outputs

--- a/helper_functions/useCallback.m
+++ b/helper_functions/useCallback.m
@@ -1,0 +1,16 @@
+function handle = useCallback(myCallback)
+% myCallback: name of matlab callback function (string)
+% handle: python handle function returned
+
+    pathToCallbackPyFile = fileparts(which('callbackP.py'));
+    
+    P = py.sys.path;
+    if count(P,pathToCallbackPyFile) == 0
+        insert(P,int32(0),pathToCallbackPyFile);
+    end
+    
+    mod = py.importlib.import_module('callbackP');
+
+    py.setattr(mod, 'callbackMatlabFunction', myCallback);
+    handle = @py.callbackP.callback;
+end


### PR DESCRIPTION
With this modifications we only need to define a matlab callback file.

In the main callback app file, we define our handle function like `handle = useCallback('nameOfCallbackFile')` instead of `py.callback.callback`.

I managed to make a couple of simple examples work. I'm trying with chained callbacks.